### PR TITLE
added Read endpoint (get by id)

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -47,11 +47,22 @@ def index():
 # NOT FINISHED, JUST A SKELETON
 @app.route("/wishlists/<int:wishlist_id>", methods=["GET"])
 def get_wishlist(wishlist_id):
-    """Placeholder for GET wishlist - to be implemented by other team members"""
-    return (
-        jsonify({"message": f"GET /wishlists/{wishlist_id} not implemented yet"}),
-        status.HTTP_501_NOT_IMPLEMENTED,
-    )
+    """
+    Retrieve a single Wishlist
+
+    This endpoint will return a Wishlist based on its ID.
+    """
+    app.logger.info("Request for Wishlist with id: %s", wishlist_id)
+
+    # See if the wishlist exists and abort if it doesn't
+    wishlist = Wishlist.find(wishlist_id)
+    if not wishlist:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Wishlist with id '{wishlist_id}' could not be found.",
+        )
+
+    return jsonify(wishlist.serialize()), status.HTTP_200_OK
 
 
 ######################################################################

--- a/tests/test_wishlist.py
+++ b/tests/test_wishlist.py
@@ -73,6 +73,20 @@ class TestWishlist(TestCase):
         self.assertEqual(wishlist.updated_at, fake_wishlist.updated_at)
         self.assertEqual(wishlist.wishlist_items, fake_wishlist.wishlist_items)
 
+    def test_read_wishlist(self):
+        """It should Read a wishlist"""
+        wishlist = WishlistFactory()
+        wishlist.create()
+
+        # Read it back
+        found_wishlist = Wishlist.find(wishlist.id)
+        self.assertEqual(found_wishlist.id, wishlist.id)
+        self.assertEqual(found_wishlist.name, wishlist.name)
+        self.assertEqual(found_wishlist.customer_id, wishlist.customer_id)
+        self.assertEqual(found_wishlist.description, wishlist.description)
+        self.assertEqual(found_wishlist.created_at, wishlist.created_at)
+        self.assertEqual(found_wishlist.updated_at, wishlist.updated_at)
+        self.assertEqual(found_wishlist.wishlist_items, [])
 
 
 ######################################################################


### PR DESCRIPTION
This pull request implements the functionality to read a single wishlist by its ID. It includes:

- A new GET /wishlists/<int:wishlist_id> route in routes.py
- Proper error handling for missing wishlists (returns 404)
- JSON serialization of the found wishlist (returns 200)


Tests Added:
- test_get_wishlist: Ensures the route successfully retrieves a wishlist
- create_wishlists helper for generating test data
- test_read_wishlist: Validates that a wishlist can be read from the database