### PR TITLE
add category to WishlistItem, expand filter query string to list route

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A RESTful microservice for managing customer wishlists allows customers to creat
 |--------|----------|-------------|
 | POST   | `/wishlists/{id}/items` | Add an item |
 | GET    | `/wishlists/{id}/items` | List all items |
-| GET    | `/wishlists/{id}/items?product_name={name}` | List items by product name |
+| GET    | `/wishlists/{id}/items?{filters}` | List items with filtering |
 | GET    | `/wishlists/{id}/items/{item_id}` | Get a specific item |
 | PUT    | `/wishlists/{id}/items/{item_id}` | Update an item |
 | DELETE | `/wishlists/{id}/items/{item_id}` | Remove an item |
@@ -83,7 +83,7 @@ tests/                     - test cases package
 ### Query Examples
 
 The API supports filtering wishlists and items using query parameters:
-
+#### Wishlist Filtering
 1. **Filter Wishlists by Customer ID**
    ```bash
    GET /wishlists?customer_id=customer123
@@ -94,9 +94,35 @@ The API supports filtering wishlists and items using query parameters:
    GET /wishlists?name=Holiday%20Wishlist
    ```
 
-3. **Filter Items by Product Name**
+#### Wishlist Item Filtering
+3. **Search Items by Product Name**
    ```bash
    GET /wishlists/{id}/items?product_name=iPhone
+   ```
+
+4. **Filter Items by Category**
+   ```bash
+   GET /wishlists/{id}/items?category=Electronics
+   ```
+
+5. **Filter Items by Price Range**
+   ```bash
+   GET /wishlists/{id}/items?min_price=100&max_price=500
+   ```
+
+6. **Combine Multiple Filters**
+   ```bash
+   # Electronics items between $100-$500
+   GET /wishlists/{id}/items?category=electronics&min_price=100&max_price=500
+
+   # Food items under $25
+   GET /wishlists/{id}/items?category=food&max_price=25
+
+   # Specific iPhone in electronics category
+   GET /wishlists/{id}/items?product_name=iPhone&category=electronics
+
+   # All filters combined
+   GET /wishlists/{id}/items?product_name=iPhone&category=electronics&min_price=100&max_price=1500
    ```
 
 ### Actions Section

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -61,6 +61,7 @@ class WishlistItemFactory(factory.Factory):
         min_value=Decimal("10.00"),
         max_value=Decimal("1000.00"),
     )
+    category = FuzzyChoice(choices=["electronics", "food", "clothing", "books", "toys", "home", None])
     created_at = FuzzyDateTime(datetime(2000, 1, 1, tzinfo=timezone.utc))
     updated_at = FuzzyDateTime(datetime(2000, 1, 1, tzinfo=timezone.utc))
     wishlist = factory.SubFactory(WishlistFactory)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -26,6 +26,7 @@ from wsgi import app
 from service.common import status
 from service.wishlist import db, Wishlist
 from tests.factories import WishlistFactory, WishlistItemFactory
+from decimal import Decimal
 
 DATABASE_URI = os.getenv(
     "DATABASE_URI", "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"
@@ -580,6 +581,278 @@ class TestWishlistService(TestCase):
         # Test DELETE method (should not be allowed)
         resp = self.client.delete(f"{BASE_URL}/{wishlist.id}/clear")
         self.assertEqual(resp.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        
+    def test_filter_items_by_category(self):
+        """It should filter items by category"""
+        # Create a wishlist
+        wishlist = self._create_wishlists(1)[0]
+        
+        # Create items with different categories
+        electronics_item = WishlistItemFactory(category="electronics", product_name="iPhone")
+        food_item = WishlistItemFactory(category="food", product_name="Pizza")
+        clothing_item = WishlistItemFactory(category="clothing", product_name="T-shirt")
+        
+        # Add all items to the wishlist
+        for item in [electronics_item, food_item, clothing_item]:
+            resp = self.client.post(
+                f"{BASE_URL}/{wishlist.id}/items",
+                json=item.serialize(),
+                content_type="application/json",
+            )
+            self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # Filter by electronics category
+        resp = self.client.get(f"{BASE_URL}/{wishlist.id}/items?category=electronics")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        
+        data = resp.get_json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["category"], "electronics")
+        self.assertEqual(data[0]["product_name"], "iPhone")
+
+    def test_filter_items_by_price_range(self):
+        """It should filter items by price range"""
+        # Create a wishlist
+        wishlist = self._create_wishlists(1)[0]
+        
+        # Create items with different prices
+        cheap_item = WishlistItemFactory(product_price=Decimal("50.00"), product_name="Cheap Item")
+        medium_item = WishlistItemFactory(product_price=Decimal("150.00"), product_name="Medium Item")
+        expensive_item = WishlistItemFactory(product_price=Decimal("500.00"), product_name="Expensive Item")
+        
+        # Add all items to the wishlist
+        for item in [cheap_item, medium_item, expensive_item]:
+            resp = self.client.post(
+                f"{BASE_URL}/{wishlist.id}/items",
+                json=item.serialize(),
+                content_type="application/json",
+            )
+            self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # Filter by price range 100-200
+        resp = self.client.get(f"{BASE_URL}/{wishlist.id}/items?min_price=100&max_price=200")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        
+        data = resp.get_json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["product_name"], "Medium Item")
+        self.assertEqual(float(data[0]["product_price"]), 150.00)
+
+    def test_filter_items_by_min_price_only(self):
+        """It should filter items by minimum price only"""
+        # Create a wishlist
+        wishlist = self._create_wishlists(1)[0]
+        
+        # Create items with different prices
+        cheap_item = WishlistItemFactory(product_price=Decimal("50.00"))
+        expensive_item = WishlistItemFactory(product_price=Decimal("500.00"))
+        
+        # Add items to the wishlist
+        for item in [cheap_item, expensive_item]:
+            resp = self.client.post(
+                f"{BASE_URL}/{wishlist.id}/items",
+                json=item.serialize(),
+                content_type="application/json",
+            )
+            self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # Filter by minimum price 100
+        resp = self.client.get(f"{BASE_URL}/{wishlist.id}/items?min_price=100")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        
+        data = resp.get_json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(float(data[0]["product_price"]), 500.00)
+
+    def test_filter_items_by_max_price_only(self):
+        """It should filter items by maximum price only"""
+        # Create a wishlist
+        wishlist = self._create_wishlists(1)[0]
+        
+        # Create items with different prices
+        cheap_item = WishlistItemFactory(product_price=Decimal("50.00"))
+        expensive_item = WishlistItemFactory(product_price=Decimal("500.00"))
+        
+        # Add items to the wishlist
+        for item in [cheap_item, expensive_item]:
+            resp = self.client.post(
+                f"{BASE_URL}/{wishlist.id}/items",
+                json=item.serialize(),
+                content_type="application/json",
+            )
+            self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # Filter by maximum price 100
+        resp = self.client.get(f"{BASE_URL}/{wishlist.id}/items?max_price=100")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        
+        data = resp.get_json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(float(data[0]["product_price"]), 50.00)
+
+    def test_filter_items_combined_filters(self):
+        """It should filter items using multiple filters combined"""
+        # Create a wishlist
+        wishlist = self._create_wishlists(1)[0]
+        
+        # Create items with different attributes
+        target_item = WishlistItemFactory(
+            category="electronics", 
+            product_price=Decimal("150.00"),
+            product_name="Target Item"
+        )
+        wrong_category = WishlistItemFactory(
+            category="food", 
+            product_price=Decimal("150.00"),
+            product_name="Wrong Category"
+        )
+        wrong_price = WishlistItemFactory(
+            category="electronics", 
+            product_price=Decimal("50.00"),
+            product_name="Wrong Price"
+        )
+        
+        # Add all items to the wishlist
+        for item in [target_item, wrong_category, wrong_price]:
+            resp = self.client.post(
+                f"{BASE_URL}/{wishlist.id}/items",
+                json=item.serialize(),
+                content_type="application/json",
+            )
+            self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # Filter by both category and price range
+        resp = self.client.get(f"{BASE_URL}/{wishlist.id}/items?category=electronics&min_price=100&max_price=200")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        
+        data = resp.get_json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["product_name"], "Target Item")
+        self.assertEqual(data[0]["category"], "electronics")
+        self.assertEqual(float(data[0]["product_price"]), 150.00)
+
+    def test_filter_items_no_results(self):
+        """It should return 404 when no items match the filters"""
+        # Create a wishlist with some items
+        wishlist = self._create_wishlists(1)[0]
+        item = WishlistItemFactory(category="electronics", product_price=Decimal("100.00"))
+        
+        resp = self.client.post(
+            f"{BASE_URL}/{wishlist.id}/items",
+            json=item.serialize(),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # Search for a category that doesn't exist
+        resp = self.client.get(f"{BASE_URL}/{wishlist.id}/items?category=nonexistent")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_filter_items_invalid_price(self):
+        """It should return 400 for invalid price parameters"""
+        wishlist = self._create_wishlists(1)[0]
+        
+        # Test invalid min_price
+        resp = self.client.get(f"{BASE_URL}/{wishlist.id}/items?min_price=invalid")
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        
+        # Test invalid max_price
+        resp = self.client.get(f"{BASE_URL}/{wishlist.id}/items?max_price=not_a_number")
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        
+    def test_filter_items_min_price_no_results(self):
+        """It should return 404 with min_price in error message when no items match min_price filter"""
+        # Create a wishlist with low-priced items
+        wishlist = self._create_wishlists(1)[0]
+        cheap_item = WishlistItemFactory(product_price=Decimal("25.00"))
+        
+        resp = self.client.post(
+            f"{BASE_URL}/{wishlist.id}/items",
+            json=cheap_item.serialize(),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # Search for items with min_price that won't match
+        resp = self.client.get(f"{BASE_URL}/{wishlist.id}/items?min_price=100")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+        
+        # Check that error message includes min_price information (correct format)
+        data = resp.get_json()
+        self.assertIn("min_price '100.0'", data["message"])
+
+    def test_filter_items_max_price_no_results(self):
+        """It should return 404 with max_price in error message when no items match max_price filter"""
+        # Create a wishlist with expensive items
+        wishlist = self._create_wishlists(1)[0]
+        expensive_item = WishlistItemFactory(product_price=Decimal("500.00"))
+        
+        resp = self.client.post(
+            f"{BASE_URL}/{wishlist.id}/items",
+            json=expensive_item.serialize(),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # Search for items with max_price that won't match
+        resp = self.client.get(f"{BASE_URL}/{wishlist.id}/items?max_price=100")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+        
+        # Check that error message includes max_price information (correct format)
+        data = resp.get_json()
+        self.assertIn("max_price '100.0'", data["message"])
+
+    def test_filter_items_price_range_no_results(self):
+        """It should return 404 with both price filters in error message when no items match price range"""
+        # Create a wishlist with items outside the search range
+        wishlist = self._create_wishlists(1)[0]
+        item = WishlistItemFactory(product_price=Decimal("500.00"))
+        
+        resp = self.client.post(
+            f"{BASE_URL}/{wishlist.id}/items",
+            json=item.serialize(),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # Search for items in a price range that won't match
+        resp = self.client.get(f"{BASE_URL}/{wishlist.id}/items?min_price=50&max_price=100")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+        
+        # Check that error message includes both price filters (correct format)
+        data = resp.get_json()
+        self.assertIn("min_price '50.0'", data["message"])
+        self.assertIn("max_price '100.0'", data["message"])
+
+    def test_filter_items_combined_filters_with_prices_no_results(self):
+        """It should return 404 with all filters in error message when no items match combined filters including prices"""
+        # Create a wishlist with items that won't match the combined filters
+        wishlist = self._create_wishlists(1)[0]
+        item = WishlistItemFactory(
+            category="electronics", 
+            product_price=Decimal("500.00"),
+            product_name="iPhone"
+        )
+        
+        resp = self.client.post(
+            f"{BASE_URL}/{wishlist.id}/items",
+            json=item.serialize(),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # Search with combined filters that won't match
+        resp = self.client.get(
+            f"{BASE_URL}/{wishlist.id}/items?category=food&product_name=Pizza&min_price=10&max_price=50"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+        
+        # Check that error message includes all filters (correct format)
+        data = resp.get_json()
+        self.assertIn("category 'food'", data["message"])        # Note: space, not =
+        self.assertIn("product_name 'Pizza'", data["message"])   # Note: space, not =
+        self.assertIn("min_price '10.0'", data["message"])       # Note: .0 decimal
+        self.assertIn("max_price '50.0'", data["message"])       # Note: .0 decimal
 
 
 ######################################################################


### PR DESCRIPTION
- Added `category` to `WishlistItem`, and relative find classmethods
- Expand the `list_wishlist_items` to be able to handle one or multiple filters string query
- Add comprehensive test cases for not only functionality but also edge cases
- Update README.md for query examples