### PR TITLE
filter by is_public status

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -61,13 +61,13 @@ def index():
 @app.route("/wishlists", methods=["GET"])
 def list_wishlists():
     """
-    List all Wishlists
-    This endpoint will return all wishlists
+    List all Wishlists with optional filters
     """
     app.logger.info("List all wishlists")
 
     customer_id = request.args.get("customer_id")
     name = request.args.get("name")
+    is_public = request.args.get("is_public")
 
     if customer_id:
         app.logger.info("Find by customer_id: %s", customer_id)
@@ -75,12 +75,22 @@ def list_wishlists():
     elif name:
         app.logger.info("Find by name: %s", name)
         wishlists = Wishlist.find_by_name(name)
+    elif is_public is not None:
+        if is_public.lower() == "true":
+            wishlists = Wishlist.find_by_visibility(True)
+        elif is_public.lower() == "false":
+            wishlists = Wishlist.find_by_visibility(False)
+        else:
+            abort(status.HTTP_400_BAD_REQUEST, "is_public must be 'true' or 'false'")
     else:
-        app.logger.info("Find all wishlists")
         wishlists = Wishlist.all()
 
-    results = [wishlist.serialize() for wishlist in wishlists]
-    app.logger.info("Returning %d wishlists", len(results))
+    results = []
+
+    for wishlist in wishlists:
+        data = wishlist.serialize()
+        results.append(data)
+
     return jsonify(results), status.HTTP_200_OK
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -878,6 +878,31 @@ class TestWishlistService(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.get_json(), {"status": "OK"})
 
+    def test_filter_wishlists_by_is_public(self):
+        """It should return Wishlists filtered by is_public value"""
+        # Create one public and one private wishlist
+        public_wishlist = WishlistFactory(is_public=True)
+        private_wishlist = WishlistFactory(is_public=False)
+
+        self.client.post(BASE_URL, json=public_wishlist.serialize())
+        self.client.post(BASE_URL, json=private_wishlist.serialize())
+
+        # Test filtering for public wishlists
+        resp = self.client.get(f"{BASE_URL}?is_public=true")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertGreaterEqual(len(data), 1)
+        for item in data:
+            self.assertTrue(item["is_public"])
+
+        # Test filtering for private wishlists
+        resp = self.client.get(f"{BASE_URL}?is_public=false")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertGreaterEqual(len(data), 1)
+        for item in data:
+            self.assertFalse(item["is_public"])
+
 
 ######################################################################
 #  T E S T   S A D   P A T H S


### PR DESCRIPTION
Added support to filter wishlists by visibility (is_public) in the /wishlists GET route. Also added corresponding tests to verify filtering for both public and private wishlists.