### PR TITLE
feat: add Tekton BDD test task using Behave

### DIFF
--- a/.tekton/bdd-task.yaml
+++ b/.tekton/bdd-task.yaml
@@ -1,0 +1,15 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: bdd-tests
+spec:
+  workspaces:
+    - name: source
+  steps:
+    - name: run-bdd-tests
+      image: python:3.11
+      workingDir: /workspace/source
+      script: |
+        pip install -r requirements.txt || pip install .
+        pip install behave
+        behave features/


### PR DESCRIPTION
This PR implements a Tekton Task named `bdd-tests` that runs BDD-style tests using `behave`, based on the existing `features/` directory in the repository.
